### PR TITLE
Allowing Rails 4.1, 4.2

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,14 +6,14 @@ UseTinyMCE
 ==========
 
 **UseTinyMCE** is yet another (as if we needed another) hack for including
-TinyMCE in a Rails 3.0, 3.1, 3.2 or 4.0 app.
+TinyMCE in a Rails 3.0, 3.1, 3.2, 4.0, 4.1, or 4.2 app.
 
 **NOTE:** Rails 3.1.0 broke version 0.0.8. The current version has been tested
 on Rails 4.0.0. It *should* work on 3.0, 3.1 and 3.2 because "nothing there has been changed". Let me know if this is not true.
 
 This gem differs from the others that I looked at on rubygems in that:
 
-1. It works with Rails [3.0](#rails_30_integration), [3.1 & 3.2](#rails_31_integration) and [4.0](#rails_40_integration) details below
+1. It works with Rails [3.0](#rails_30_integration), [3.1 & 3.2](#rails_31_integration) and [4.0, 4.1, & 4.2](#rails_40_integration) details below
 2. It's minimal. It does not provide any juicy Rails style configuration for
 TinyMCE. You just use the config stuff which comes with TinyMCE - in javascript.
 3. I've moved on to Ruby 2.0, so I'm now depending on others to find and patch bugs in 1.9.x
@@ -29,7 +29,7 @@ supports both *raw* TinyMCE (which works well with Prototype) and the *jquery* v
 which works with 'jquery'. It also supports both *simple* and *advanced* editor
 installations for the *raw* type.
 
-**Rails 3.1, 3.2 and 4.0 Note:** TinyMCE doesn't play well with the asset pipeline, so it is installed
+**Rails 3.1, 3.2, 4.0, 4.1, 4.2 Note:** TinyMCE doesn't play well with the asset pipeline, so it is installed
 in public. This has to do with the way TinyMCE is architected: it is plugin based
 and scatters javascript, css, and html all through it's plugin directory. It manages it's
 own loading.
@@ -87,7 +87,7 @@ If you don't need much and aren't familiar with *TinyMCE*, then `rake use_tinymc
 should be fine. The *advanced* version configures *TinyMCE* with many more features. Go to
 the ["TinyMCE website for details"](http://tinymce.moxiecode.com/)
 
-Rails 3.1, 3.2 and 4.0
+Rails 3.1, 3.2, 4.0, 4.1, 4.2
 
 * `rake use_tinymce:install` - installs the jQuery version of TinyMCE
 * `rake use_tinymce:uninstall` - removes all trace of TinyMCE & the initialization file from
@@ -132,7 +132,7 @@ by a previous call to `use_tinymce` [or if you included `use_tinymce :all` in yo
 ## Rake Tasks:
 
 **NOTE** `assets` here refers to the `assets` directory in the `use_tinymce`
-gem - **not** the Rails 3.1, 3.2 and 4.0 asset pipeline directory.
+gem - **not** the Rails 3.1, 3.2, 4.0, 4.1, 4.2 asset pipeline directory.
 
 This initialization scripts were copied literally from the TinyMCE website
 ["For Dummies" page](http://tinymce.moxiecode.com/wiki.php/%22For_Dummies%22)
@@ -168,11 +168,11 @@ directory from your applications `public/javascripts`
 `rake use_tinymce::install_*` to insure you get a clean installation. This will also
 *clean* out any customization you have done.
 
-### Rails 3.1, 3.2 and 4.0
+### Rails 3.1, 3.2, 4.0, 4.1, 4.2
 
 **NOTE** I no longer support this gem for Rails 3.1 and 3.2. I will accept patches, but will not test them.
 
-`use_tinymce` only supports installing the jQuery version of TinyMCE on Rails 3.1, 3.2 and 4.0.
+`use_tinymce` only supports installing the jQuery version of TinyMCE on Rails 3.1, 3.2, 4.0, 4.1, 4.2.
 
 There are two Rake tasks:
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ end
 
 desc "create README.markdown from README.markdown.in by replacing @@FOO@@ with FOO Value"
 file "README.markdown" => ["README.markdown.in"] do
-  system "sed -e 's/@@VERSION@@/#{VERSION}/g' <'README.markdown.in' >'README.markdown'"
+  system "sed -e 's/@@VERSION@@/#{UseTinymce::VERSION}/g' <'README.markdown.in' >'README.markdown'"
 end
 
 desc "build gem"
@@ -33,7 +33,7 @@ end
 
 desc "push to rubygems"
 task :gem_push => [:gem] do
-  unless VERSION =~ /pre/ then
+  unless UseTinymce::VERSION =~ /pre/ then
     system "gem push #{gem_name}-#{gem_version}.gem"
   else
     puts "Cannot push a pre version - test it you fool!!!!"

--- a/lib/tasks/use_tinymce.rake
+++ b/lib/tasks/use_tinymce.rake
@@ -1,17 +1,16 @@
 require 'fileutils'
-
 # make sure we are in the right versino of Rails
 unless defined?(Rails)
   puts "This rake task only runs on Rails"
   exit
 end
-unless Rails.version =~ /^3.[012]/ || Rails.version =~ /^4.[0]/
+unless Rails.version =~ UseTinymce::RAILS_3_VERSIONS || Rails.version =~ UseTinymce::RAILS_4_VERSIONS
   puts "use_tinymce Error: Don't know how to install on Rails Version #{Rails.version}"
 
   exit
 end
 
-module UseTinyMCE
+module UseTinymce
   module RakeSupport
     # gem paths - used to source for installation
     USE_TINYMCE_ROOT = File.expand_path('../../../', __FILE__)
@@ -78,53 +77,53 @@ end
 namespace :use_tinymce do
   desc "uninstall use_tinymce javascript code"
   task :uninstall do
-    init_file_path = File.join(UseTinyMCE::RakeSupport::JAVASCRIPT_ROOT, 'use_tinymce_init.js')
+    init_file_path = File.join(UseTinymce::RakeSupport::JAVASCRIPT_ROOT, 'use_tinymce_init.js')
     File.delete(init_file_path) if File.exists? init_file_path
     
-    tinymce_root_path = File.join(UseTinyMCE::RakeSupport::JAVASCRIPT_ROOT, 'tinymce')
-    UseTinyMCE::RakeSupport::rmdir_tree(tinymce_root_path) if File.exists? tinymce_root_path
+    tinymce_root_path = File.join(UseTinymce::RakeSupport::JAVASCRIPT_ROOT, 'tinymce')
+    UseTinymce::RakeSupport::rmdir_tree(tinymce_root_path) if File.exists? tinymce_root_path
   end
 
   case Rails.version
   when /^3.0/
     # common task - this undescribed task installs the non-jquery version of TinyMCE, but not the initialization script
     task :install_tinymce_advanced => :uninstall do
-      raise Exception.new("Cannot install: #{UseTinyMCE::RakeSupport::JAVASCRIPT_ROOT} does not exist") unless UseTinyMCE::RakeSupport.mkdir_tree UseTinyMCE::RakeSupport::JAVASCRIPT_ROOT
-      FileUtils.cp_r File.join(UseTinyMCE::RakeSupport::ASSETS_ROOT, 'tinymce_no_jquery', 'tinymce'), UseTinyMCE::RakeSupport::JAVASCRIPT_ROOT
+      raise Exception.new("Cannot install: #{UseTinymce::RakeSupport::JAVASCRIPT_ROOT} does not exist") unless UseTinymce::RakeSupport.mkdir_tree UseTinymce::RakeSupport::JAVASCRIPT_ROOT
+      FileUtils.cp_r File.join(UseTinymce::RakeSupport::ASSETS_ROOT, 'tinymce_no_jquery', 'tinymce'), UseTinymce::RakeSupport::JAVASCRIPT_ROOT
     end
     # common task - this undescribed task installs the jquery version of TinyMCE, but not the initialization script
     task :install_tinymce_jquery => :uninstall do
-      raise Exception.new("Cannot install: #{UseTinyMCE::RakeSupport::JAVASCRIPT_ROOT} does not exist") unless UseTinyMCE::RakeSupport.mkdir_tree UseTinyMCE::RakeSupport::JAVASCRIPT_ROOT
-      FileUtils.cp_r File.join(UseTinyMCE::RakeSupport::ASSETS_ROOT, 'tinymce_jquery', 'tinymce'), UseTinyMCE::RakeSupport::JAVASCRIPT_ROOT
+      raise Exception.new("Cannot install: #{UseTinymce::RakeSupport::JAVASCRIPT_ROOT} does not exist") unless UseTinymce::RakeSupport.mkdir_tree UseTinymce::RakeSupport::JAVASCRIPT_ROOT
+      FileUtils.cp_r File.join(UseTinymce::RakeSupport::ASSETS_ROOT, 'tinymce_jquery', 'tinymce'), UseTinymce::RakeSupport::JAVASCRIPT_ROOT
     end
 
     desc "Install tinymce with 'simple' initialization"
     task :install_simple => :install_tinymce_advanced do
-      UseTinyMCE::RakeSupport::copy_init_script('use_tinymce_init_simple.js')
+      UseTinymce::RakeSupport::copy_init_script('use_tinymce_init_simple.js')
     end
 
     desc "Install tinymce with 'advanced' initialization"
     task :install_advanced => :install_tinymce_advanced do
-      UseTinyMCE::RakeSupport::copy_init_script('use_tinymce_init_advanced.js')
+      UseTinymce::RakeSupport::copy_init_script('use_tinymce_init_advanced.js')
     end
 
     desc "Install tinymce jquery plugin with 'advanced' initialization"
     task :install_jquery => :install_tinymce_jquery do
-      UseTinyMCE::RakeSupport::copy_init_script('use_tinymce_init_jquery.js')
+      UseTinymce::RakeSupport::copy_init_script('use_tinymce_init_jquery.js')
     end
   when /^3\.[12]/
     desc "Install tinymce jquery plugin with 'advanced' initialization"
     task :install => :uninstall do
-      raise Exception.new("Cannot install: #{UseTinyMCE::RakeSupport::JAVASCRIPT_ROOT} does not exist") unless UseTinyMCE::RakeSupport.mkdir_tree UseTinyMCE::RakeSupport::JAVASCRIPT_ROOT
-      FileUtils.cp_r File.join(UseTinyMCE::RakeSupport::ASSETS_ROOT, 'tinymce_jquery', 'tinymce'), UseTinyMCE::RakeSupport::JAVASCRIPT_ROOT
-      UseTinyMCE::RakeSupport::copy_init_script('use_tinymce_init_jquery.js')
+      raise Exception.new("Cannot install: #{UseTinymce::RakeSupport::JAVASCRIPT_ROOT} does not exist") unless UseTinymce::RakeSupport.mkdir_tree UseTinymce::RakeSupport::JAVASCRIPT_ROOT
+      FileUtils.cp_r File.join(UseTinymce::RakeSupport::ASSETS_ROOT, 'tinymce_jquery', 'tinymce'), UseTinymce::RakeSupport::JAVASCRIPT_ROOT
+      UseTinymce::RakeSupport::copy_init_script('use_tinymce_init_jquery.js')
     end
-  when /^4\.[0]/
+  when UseTinymce::RAILS_4_VERSIONS
     desc "Install tinymce jquery plugin with 'advanced' initialization"
     task :install => :uninstall do
-      raise Exception.new("Cannot install: #{UseTinyMCE::RakeSupport::JAVASCRIPT_ROOT} does not exist") unless UseTinyMCE::RakeSupport.mkdir_tree UseTinyMCE::RakeSupport::JAVASCRIPT_ROOT
-      FileUtils.cp_r File.join(UseTinyMCE::RakeSupport::ASSETS_ROOT, 'tinymce_jquery_4_0_2', 'tinymce'), UseTinyMCE::RakeSupport::JAVASCRIPT_ROOT
-      UseTinyMCE::RakeSupport::copy_init_script('use_tinymce_init_jquery_4_0_2.js')
+      raise Exception.new("Cannot install: #{UseTinymce::RakeSupport::JAVASCRIPT_ROOT} does not exist") unless UseTinymce::RakeSupport.mkdir_tree UseTinymce::RakeSupport::JAVASCRIPT_ROOT
+      FileUtils.cp_r File.join(UseTinymce::RakeSupport::ASSETS_ROOT, 'tinymce_jquery_4_0_2', 'tinymce'), UseTinymce::RakeSupport::JAVASCRIPT_ROOT
+      UseTinymce::RakeSupport::copy_init_script('use_tinymce_init_jquery_4_0_2.js')
     end
     # desc "Remove tinymce jquery plugin and re-install it - WARNING: Destroys your customizations"
     # task :reinstall => :uninstall do |tsk|

--- a/lib/use_tinymce.rb
+++ b/lib/use_tinymce.rb
@@ -1,3 +1,4 @@
+require 'use_tinymce/version'
 require 'use_tinymce/use_tinymce'
 if defined? Rails
   require 'use_tinymce/railengine'

--- a/lib/use_tinymce/railengine.rb
+++ b/lib/use_tinymce/railengine.rb
@@ -1,6 +1,6 @@
 module UseTinymce
   class Engine < Rails::Engine
-    if Rails.version =~ /^3.[012]/ || Rails.version =~ /^4.[0]/
+    if Rails.version =~ RAILS_3_VERSIONS || Rails.version =~ RAILS_4_VERSIONS
       initializer "active_support.add_use_tinymce" do
         ::ActiveSupport.on_load(:action_controller) do
           include UseTinymce::Base

--- a/lib/use_tinymce/use_tinymce.rb
+++ b/lib/use_tinymce/use_tinymce.rb
@@ -25,7 +25,7 @@ module UseTinymce
   
   if defined? Rails
     module Link
-      if Rails.version =~ /^3.[012]/ || Rails.version =~ /^4.[0]/
+      if Rails.version =~ RAILS_3_VERSIONS || Rails.version =~ RAILS_4_VERSIONS
         def use_tinymce_link
           if defined?(params) && use_tinymce?(params[:action])
             ret = ''

--- a/lib/use_tinymce/version.rb
+++ b/lib/use_tinymce/version.rb
@@ -1,1 +1,5 @@
-VERSION = '1.0.snapshot'
+module UseTinymce
+  VERSION = '1.0.snapshot.1'
+  RAILS_3_VERSIONS = /^3.[012]/
+  RAILS_4_VERSIONS = /^4.[012]/
+end

--- a/use_tinymce.gemspec
+++ b/use_tinymce.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.files = Dir["{lib,test}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.markdown"] \
     + ["assets/use_tinymce_init_simple.js", "assets/use_tinymce_init_advanced.js", "assets/use_tinymce_init_jquery.js"] \
     + Dir['assets/tinymce*/**/*']
-  s.version = VERSION
+  s.version = UseTinymce::VERSION
 end


### PR DESCRIPTION
Allowing Rails 4.1, 4.2

Extracted

``` ruby
UseTinymce::VERSION
UseTinymce::RAILS_3_VERSIONS
UseTinymce::RAILS_4_VERSIONS
```

Version v1.0.snapshot.1
